### PR TITLE
Add commonly generated intermediary file (LaTeX)

### DIFF
--- a/templates/tex.patch
+++ b/templates/tex.patch
@@ -1,0 +1,2 @@
+## Intermediate documents:
+*Notes.bib


### PR DESCRIPTION
pdflatex generates *filename*Notes.bib whenever the document class incorporates footnotes in the bibilography (commonly used, see e.g. the popular [revtex](https://www.ctan.org/pkg/revtex4-1) class).
Ignore this.